### PR TITLE
Fix UI auth tab and sanitize messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta name="format-detection" content="telephone=no">
     <meta name="referrer" content="no-referrer">
     <title>JustLayMe - AI Companions</title>
+    <meta name="description" content="Chat with customizable AI companions.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
@@ -433,8 +434,8 @@
     <div id="authContainer" class="auth-container">
         <div class="auth-card">
             <div class="auth-tabs">
-                <button class="auth-tab active" onclick="switchAuthTab('login')">Login</button>
-                <button class="auth-tab" onclick="switchAuthTab('signup')">Sign Up</button>
+                <button class="auth-tab active" onclick="switchAuthTab('login', event)">Login</button>
+                <button class="auth-tab" onclick="switchAuthTab('signup', event)">Sign Up</button>
             </div>
             
             <form class="auth-form" onsubmit="handleAuth(event)">
@@ -713,6 +714,7 @@
         let isPremium = false;
         let currentCharacter = 'uncensored_gpt';
         let authMode = 'login';
+        const GOOGLE_CLIENT_ID = window.GOOGLE_CLIENT_ID || '';
 
         // Initialize
         window.onload = function() {
@@ -733,10 +735,10 @@
             }
         }
 
-        function switchAuthTab(mode) {
+        function switchAuthTab(mode, evt) {
             authMode = mode;
             document.querySelectorAll('.auth-tab').forEach(tab => tab.classList.remove('active'));
-            event.target.classList.add('active');
+            if (evt) evt.target.classList.add('active');
             
             const confirmPassword = document.getElementById('authConfirmPassword');
             const submitBtn = document.getElementById('authSubmitBtn');
@@ -892,9 +894,9 @@
 
         // Google Sign-In functions
         function initializeGoogleSignIn() {
-            if (typeof google !== 'undefined') {
+            if (typeof google !== 'undefined' && GOOGLE_CLIENT_ID) {
                 google.accounts.id.initialize({
-                    client_id: "YOUR_GOOGLE_CLIENT_ID", // You'll need to set this up
+                    client_id: GOOGLE_CLIENT_ID,
                     callback: handleGoogleSignIn
                 });
             }
@@ -1151,12 +1153,19 @@
             const messagesArea = document.getElementById('messages');
             const messageDiv = document.createElement('div');
             messageDiv.className = `message ${sender}`;
-            
-            messageDiv.innerHTML = `
-                <div class="message-avatar">${sender === 'ai' ? getCharacterEmoji(currentCharacter) : ''}</div>
-                <div class="message-content">${text}</div>
-            `;
-            
+
+            const avatarDiv = document.createElement('div');
+            avatarDiv.className = 'message-avatar';
+            if (sender === 'ai') {
+                avatarDiv.innerHTML = getCharacterEmoji(currentCharacter);
+            }
+
+            const contentDiv = document.createElement('div');
+            contentDiv.className = 'message-content';
+            contentDiv.textContent = text;
+
+            messageDiv.appendChild(avatarDiv);
+            messageDiv.appendChild(contentDiv);
             messagesArea.appendChild(messageDiv);
             messagesArea.scrollTop = messagesArea.scrollHeight;
         }

--- a/payment-integration.js
+++ b/payment-integration.js
@@ -1,8 +1,8 @@
 // Payment Integration for JustLayMe Premium
 // This integrates with Stripe for payment processing
 
-// Initialize Stripe (you'll need to add your publishable key)
-const STRIPE_PUBLISHABLE_KEY = 'pk_test_YOUR_KEY_HERE';
+// Initialize Stripe using a global variable for your publishable key
+const STRIPE_PUBLISHABLE_KEY = window.STRIPE_PUBLISHABLE_KEY || '';
 let stripe = null;
 
 // Price IDs from Stripe Dashboard
@@ -179,7 +179,7 @@ function addStripeEndpoints(app) {
 }
 
 // Alternative: PayPal Integration
-const PAYPAL_CLIENT_ID = 'YOUR_PAYPAL_CLIENT_ID';
+const PAYPAL_CLIENT_ID = window.PAYPAL_CLIENT_ID || '';
 
 function initializePayPal() {
     // Add PayPal script to page


### PR DESCRIPTION
## Summary
- add meta description
- pass click event to `switchAuthTab` and update the function
- avoid innerHTML when inserting chat messages
- allow Google, Stripe and PayPal IDs to be set via global variables

## Testing
- `node --check payment-integration.js`


------
https://chatgpt.com/codex/tasks/task_e_684f42f438788321855a278f91d765e4